### PR TITLE
run nspawn with SYSTEMD_SECCOMP=0

### DIFF
--- a/nspawn-runner
+++ b/nspawn-runner
@@ -174,7 +174,7 @@ class Machine:
             'WatchdogSec=3min',
         ]
 
-        systemd_run_cmd = ["systemd-run"]
+        systemd_run_cmd = ["systemd-run", "--setenv=SYSTEMD_SECCOMP=0"]
         for c in unit_config:
             systemd_run_cmd.append(f"--property={c}")
 


### PR DESCRIPTION
This is related to https://github.com/systemd/systemd/issues/18370
i'm not *really* sure it makes a difference, but i found nspawn to be somewhat slow on my server with supposedly fast storage.