### PR TITLE
Do not rely on systemd being in PATH

### DIFF
--- a/nspawn-runner
+++ b/nspawn-runner
@@ -98,7 +98,7 @@ class NspawnRunner:
         self.root_dir = root_dir
         self.gitlab_build_dir = os.path.join(self.root_dir, ".build")
         self.gitlab_cache_dir = os.path.join(self.root_dir, ".cache")
-        res = subprocess.run(["systemd", "--version"], check=True, capture_output=True, text=True)
+        res = subprocess.run(["systemd-nspawn", "--version"], check=True, capture_output=True, text=True)
         self.systemd_version = int(res.stdout.splitlines()[0].split()[1])
 
     @classmethod


### PR DESCRIPTION
systemd is not supposed to be in PATH (see e.g. https://bugs.debian.org/913061) and no longer is on current Debian, so use systemd-nspawn instead to retrieve the version.